### PR TITLE
fix: disable pinch zoom on mobile(#1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <link rel="icon" type="image/svg+xml" href="/web-components.svg" />
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+      content="width=device-width, initial-scale=1, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no"
     />
     <title>Guitar Metronome</title>
   </head>


### PR DESCRIPTION
Typically, we would set it like this:

- width=device-width: This ensures that the width of the viewport is set to the width of the device, adapting the page layout accordingly.
- initial-scale=1: This sets the initial scaling factor to 1, ensuring that the page is displayed at the default scale without any zooming or scaling applied.
- maximum-scale=1.0 and minimum-scale=1.0: These attributes set both the maximum and minimum scaling factors to 1, effectively preventing the user from zooming in or out on the page. The page remains locked at the initial scale.
- user-scalable=no: This attribute disables the ability for the user to manually zoom or scale the page, ensuring that the page remains fixed at the initial scale.